### PR TITLE
Add Query Key + CI build.sh check

### DIFF
--- a/.github/workflows/ci.check-build-consistency.yml
+++ b/.github/workflows/ci.check-build-consistency.yml
@@ -11,13 +11,13 @@ jobs:
       
       - name: Check committed files against built files
         run: |
-          main-list-committed-hash=`echo hashfiles('./main/networks/list.cjs')`
-          module-list-committed-hash=`echo hashfiles('./module/networks/list.js')`
+          main_list_committed_hash=`echo hashfiles('./main/networks/list.cjs')`
+          module_list_committed_hash=`echo hashfiles('./module/networks/list.js')`
           
           ./build.sh
           
-          main-list-built-hash=`echo hashfiles('./main/networks/list.cjs')`
-          module-list-built-hash=`echo hashfiles('./module/networks/list.js')`
+          main_list_built_hash=`echo hashfiles('./main/networks/list.cjs')`
+          module_list_built_hash=`echo hashfiles('./module/networks/list.js')`
 
           if [ "$main-list-committed-hash" != "$main-list-built-hash" || "$module-list-committed-hash" != "$module-list-built-hash" ]; then
             echo "The built files are not consistent with the committed files. Please run ./build.sh and commit the changes."

--- a/.github/workflows/ci.check-build-consistency.yml
+++ b/.github/workflows/ci.check-build-consistency.yml
@@ -11,13 +11,13 @@ jobs:
       
       - name: Check committed files against built files
         run: |
-          main_list_committed_hash=`echo hashfiles('./main/networks/list.cjs')`
-          module_list_committed_hash=`echo hashfiles('./module/networks/list.js')`
+          main_list_committed_hash=`echo hashFiles('./main/networks/list.cjs')`
+          module_list_committed_hash=`echo hashFiles('./module/networks/list.js')`
           
           ./build.sh
           
-          main_list_built_hash=`echo hashfiles('./main/networks/list.cjs')`
-          module_list_built_hash=`echo hashfiles('./module/networks/list.js')`
+          main_list_built_hash=`echo hashFiles('./main/networks/list.cjs')`
+          module_list_built_hash=`echo hashFiles('./module/networks/list.js')`
 
           if [ "$main-list-committed-hash" != "$main-list-built-hash" || "$module-list-committed-hash" != "$module-list-built-hash" ]; then
             echo "The built files are not consistent with the committed files. Please run ./build.sh and commit the changes."

--- a/.github/workflows/ci.check-build-consistency.yml
+++ b/.github/workflows/ci.check-build-consistency.yml
@@ -10,21 +10,5 @@ jobs:
       - uses: actions/checkout@v3
       
       - name: Check committed files against built files
-        run: |
-          function hashFiles() {
-            sha256sum $1 | cut -d ' ' -f 1
-          }
-
-          main_list_committed_hash=$(sha256sum ./main/networks/list.cjs)
-          module_list_committed_hash=$(sha256sum ./module/networks/list.js)
-          
-          ./build.sh
-          
-          main_list_built_hash=$('./main/networks/list.cjs')
-          module_list_built_hash=$('./module/networks/list.js')
-
-          if [ "$main-list-committed-hash" != "$main-list-built-hash" || "$module-list-committed-hash" != "$module-list-built-hash" ]; then
-            echo "The built files are not consistent with the committed files. Please run ./build.sh and commit the changes."
-            exit 1
-          fi
+        run: ./compare-committed-against-build.sh
           

--- a/.github/workflows/ci.check-build-consistency.yml
+++ b/.github/workflows/ci.check-build-consistency.yml
@@ -11,8 +11,12 @@ jobs:
       
       - name: Check committed files against built files
         run: |
-          main_list_committed_hash=`echo hashFiles('./main/networks/list.cjs')`
-          module_list_committed_hash=`echo hashFiles('./module/networks/list.js')`
+          function hashFiles() {
+            sha256sum $1 | cut -d ' ' -f 1
+          }
+
+          main_list_committed_hash=$(sha256sum ./main/networks/list.cjs)
+          module_list_committed_hash=$(sha256sum ./module/networks/list.js)
           
           ./build.sh
           

--- a/.github/workflows/ci.check-build-consistency.yml
+++ b/.github/workflows/ci.check-build-consistency.yml
@@ -1,0 +1,26 @@
+name: CI | Check build.sh output against committed files
+
+on:
+  pull_request:
+    
+jobs:
+  check-build-sh-output:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      
+      - name: Check committed files against built files
+        run: |
+          main-list-committed-hash=`echo hashfiles(./main/networks/list.cjs)`
+          module-list-committed-hash=`echo hashfiles(./module/networks/list.js)`
+          
+          ./build.sh
+          
+          main-list-built-hash=`echo hashfiles(./main/networks/list.cjs)`
+          module-list-built-hash=`echo hashfiles(./module/networks/list.js)`
+
+          if [ "$main-list-committed-hash" != "$main-list-built-hash" || "$module-list-committed-hash" != "$module-list-built-hash" ]; then
+            echo "The built files are not consistent with the committed files. Please run ./build.sh and commit the changes."
+            exit 1
+          fi
+          

--- a/.github/workflows/ci.check-build-consistency.yml
+++ b/.github/workflows/ci.check-build-consistency.yml
@@ -20,8 +20,8 @@ jobs:
           
           ./build.sh
           
-          main_list_built_hash=`echo hashFiles('./main/networks/list.cjs')`
-          module_list_built_hash=`echo hashFiles('./module/networks/list.js')`
+          main_list_built_hash=$('./main/networks/list.cjs')
+          module_list_built_hash=$('./module/networks/list.js')
 
           if [ "$main-list-committed-hash" != "$main-list-built-hash" || "$module-list-committed-hash" != "$module-list-built-hash" ]; then
             echo "The built files are not consistent with the committed files. Please run ./build.sh and commit the changes."

--- a/.github/workflows/ci.check-build-consistency.yml
+++ b/.github/workflows/ci.check-build-consistency.yml
@@ -11,13 +11,13 @@ jobs:
       
       - name: Check committed files against built files
         run: |
-          main-list-committed-hash=`echo hashfiles(./main/networks/list.cjs)`
-          module-list-committed-hash=`echo hashfiles(./module/networks/list.js)`
+          main-list-committed-hash=`echo hashfiles('./main/networks/list.cjs')`
+          module-list-committed-hash=`echo hashfiles('./module/networks/list.js')`
           
           ./build.sh
           
-          main-list-built-hash=`echo hashfiles(./main/networks/list.cjs)`
-          module-list-built-hash=`echo hashfiles(./module/networks/list.js)`
+          main-list-built-hash=`echo hashfiles('./main/networks/list.cjs')`
+          module-list-built-hash=`echo hashfiles('./module/networks/list.js')`
 
           if [ "$main-list-committed-hash" != "$main-list-built-hash" || "$module-list-committed-hash" != "$module-list-built-hash" ]; then
             echo "The built files are not consistent with the committed files. Please run ./build.sh and commit the changes."

--- a/build.sh
+++ b/build.sh
@@ -1,8 +1,13 @@
 #!/bin/bash
+# This script builds the files in the main and module directories.
+
 rm main/networks/list.cjs
 rm module/networks/list.js
+
 touch main/networks/list.cjs
 touch module/networks/list.js
+
 echo 'module.exports =' > main/networks/list.cjs
 echo 'export default' > module/networks/list.js
+
 cat networks.json | tee -a main/networks/list.cjs  module/networks/list.js > /dev/null

--- a/compare-committed-against-build.sh
+++ b/compare-committed-against-build.sh
@@ -17,7 +17,7 @@ main_list_built_hash=$(hashFiles './main/networks/list.cjs')
 module_list_built_hash=$(hashFiles './module/networks/list.js')
 
 # Compare the hashes and exit if they are not equal
-if [ "$main_list_committed_hash" != "$main_list_built_hash" || "$module_list_committed_hash" != "$module_list_built_hash" ]; then
+if [ "$main_list_committed_hash" != "$main_list_built_hash"] || ["$module_list_committed_hash" != "$module_list_built_hash" ]; then
     echo "The built files are not consistent with the committed files. Please run ./build.sh and commit the changes."
     exit 1
 fi

--- a/compare-committed-against-build.sh
+++ b/compare-committed-against-build.sh
@@ -1,0 +1,23 @@
+#!/bin/bash
+# This script checks that the built files are consistent with the committed files.
+
+function hashFiles() {
+    sha256sum $1 | cut -d ' ' -f 1
+}
+
+# Hash the commited files
+main_list_committed_hash=$(hashFiles ./main/networks/list.cjs)
+module_list_committed_hash=$(hashFiles ./module/networks/list.js)
+
+# Build the files
+./build.sh
+
+# Hash the built files
+main_list_built_hash=$(hashFiles './main/networks/list.cjs')
+module_list_built_hash=$(hashFiles './module/networks/list.js')
+
+# Compare the hashes and exit if they are not equal
+if [ "$main_list_committed_hash" != "$main_list_built_hash" || "$module_list_committed_hash" != "$module_list_built_hash" ]; then
+    echo "The built files are not consistent with the committed files. Please run ./build.sh and commit the changes."
+    exit 1
+fi

--- a/compare-committed-against-build.sh
+++ b/compare-committed-against-build.sh
@@ -1,6 +1,9 @@
 #!/bin/bash
 # This script checks that the built files are consistent with the committed files.
 
+set -xe
+
+# Hash a file using sha256sum and cut the hash from the output
 function hashFiles() {
     sha256sum $1 | cut -d ' ' -f 1
 }
@@ -17,7 +20,7 @@ main_list_built_hash=$(hashFiles './main/networks/list.cjs')
 module_list_built_hash=$(hashFiles './module/networks/list.js')
 
 # Compare the hashes and exit if they are not equal
-if [ "$main_list_committed_hash" != "$main_list_built_hash"] || ["$module_list_committed_hash" != "$module_list_built_hash" ]; then
+if [ "$main_list_committed_hash" != "$main_list_built_hash" ] || [ "$module_list_committed_hash" != "$module_list_built_hash" ]; then
     echo "The built files are not consistent with the committed files. Please run ./build.sh and commit the changes."
     exit 1
 fi

--- a/main/networks/list.cjs
+++ b/main/networks/list.cjs
@@ -102,7 +102,7 @@ module.exports =
         "explorer": "https://goerli.arbiscan.io",
         "subgraphV1": {
             "name": "protocol-v1-arbitrum-goerli",
-            "hostedEndpoint": "https://subgraph.satsuma-prod.com/superfluid/arbitrum-goerli/api"
+            "hostedEndpoint": "https://subgraph.satsuma-prod.com/c5br3jaVlJI6/superfluid/arbitrum-goerli/api"
         }
     },
     {
@@ -156,7 +156,7 @@ module.exports =
         "explorer": "https://gnosisscan.io",
         "subgraphV1": {
             "name": "protocol-v1-xdai",
-            "hostedEndpoint": "https://subgraph.satsuma-prod.com/superfluid/xdai/api"
+            "hostedEndpoint": "https://subgraph.satsuma-prod.com/c5br3jaVlJI6/superfluid/xdai/api"
         }
     },
     {
@@ -324,7 +324,7 @@ module.exports =
         "explorer": "https://etherscan.io",
         "subgraphV1": {
             "name": "protocol-v1-eth-mainnet",
-            "hostedEndpoint": "https://subgraph.satsuma-prod.com/superfluid/eth-mainnet/api"
+            "hostedEndpoint": "https://subgraph.satsuma-prod.com/c5br3jaVlJI6/superfluid/eth-mainnet/api"
         }
     }
 ]

--- a/main/networks/list.cjs
+++ b/main/networks/list.cjs
@@ -102,7 +102,7 @@ module.exports =
         "explorer": "https://goerli.arbiscan.io",
         "subgraphV1": {
             "name": "protocol-v1-arbitrum-goerli",
-            "hostedEndpoint": "https://subgraph.satsuma-prod.com/c5br3jaVlJI6/superfluid/arbitrum-goerli/api"
+            "hostedEndpoint": "https://api.thegraph.com/subgraphs/name/superfluid-finance/protocol-v1-arbitrum-goerli"
         }
     },
     {
@@ -156,7 +156,7 @@ module.exports =
         "explorer": "https://gnosisscan.io",
         "subgraphV1": {
             "name": "protocol-v1-xdai",
-            "hostedEndpoint": "https://subgraph.satsuma-prod.com/c5br3jaVlJI6/superfluid/xdai/api"
+            "hostedEndpoint": "https://api.thegraph.com/subgraphs/name/superfluid-finance/protocol-v1-xdai"
         }
     },
     {
@@ -324,7 +324,7 @@ module.exports =
         "explorer": "https://etherscan.io",
         "subgraphV1": {
             "name": "protocol-v1-eth-mainnet",
-            "hostedEndpoint": "https://subgraph.satsuma-prod.com/c5br3jaVlJI6/superfluid/eth-mainnet/api"
+            "hostedEndpoint": "https://api.thegraph.com/subgraphs/name/superfluid-finance/protocol-v1-eth-mainnet"
         }
     }
 ]

--- a/module/networks/list.js
+++ b/module/networks/list.js
@@ -102,7 +102,7 @@ export default
         "explorer": "https://goerli.arbiscan.io",
         "subgraphV1": {
             "name": "protocol-v1-arbitrum-goerli",
-            "hostedEndpoint": "https://subgraph.satsuma-prod.com/c5br3jaVlJI6/superfluid/arbitrum-goerli/api"
+            "hostedEndpoint": "https://api.thegraph.com/subgraphs/name/superfluid-finance/protocol-v1-arbitrum-goerli"
         }
     },
     {
@@ -156,7 +156,7 @@ export default
         "explorer": "https://gnosisscan.io",
         "subgraphV1": {
             "name": "protocol-v1-xdai",
-            "hostedEndpoint": "https://subgraph.satsuma-prod.com/c5br3jaVlJI6/superfluid/xdai/api"
+            "hostedEndpoint": "https://api.thegraph.com/subgraphs/name/superfluid-finance/protocol-v1-xdai"
         }
     },
     {
@@ -324,7 +324,7 @@ export default
         "explorer": "https://etherscan.io",
         "subgraphV1": {
             "name": "protocol-v1-eth-mainnet",
-            "hostedEndpoint": "https://subgraph.satsuma-prod.com/c5br3jaVlJI6/superfluid/eth-mainnet/api"
+            "hostedEndpoint": "https://api.thegraph.com/subgraphs/name/superfluid-finance/protocol-v1-eth-mainnet"
         }
     }
 ]

--- a/module/networks/list.js
+++ b/module/networks/list.js
@@ -102,7 +102,7 @@ export default
         "explorer": "https://goerli.arbiscan.io",
         "subgraphV1": {
             "name": "protocol-v1-arbitrum-goerli",
-            "hostedEndpoint": "https://subgraph.satsuma-prod.com/superfluid/arbitrum-goerli/api"
+            "hostedEndpoint": "https://subgraph.satsuma-prod.com/c5br3jaVlJI6/superfluid/arbitrum-goerli/api"
         }
     },
     {
@@ -156,7 +156,7 @@ export default
         "explorer": "https://gnosisscan.io",
         "subgraphV1": {
             "name": "protocol-v1-xdai",
-            "hostedEndpoint": "https://subgraph.satsuma-prod.com/superfluid/xdai/api"
+            "hostedEndpoint": "https://subgraph.satsuma-prod.com/c5br3jaVlJI6/superfluid/xdai/api"
         }
     },
     {
@@ -324,7 +324,7 @@ export default
         "explorer": "https://etherscan.io",
         "subgraphV1": {
             "name": "protocol-v1-eth-mainnet",
-            "hostedEndpoint": "https://subgraph.satsuma-prod.com/superfluid/eth-mainnet/api"
+            "hostedEndpoint": "https://subgraph.satsuma-prod.com/c5br3jaVlJI6/superfluid/eth-mainnet/api"
         }
     }
 ]

--- a/networks.json
+++ b/networks.json
@@ -101,7 +101,7 @@
         "explorer": "https://goerli.arbiscan.io",
         "subgraphV1": {
             "name": "protocol-v1-arbitrum-goerli",
-            "hostedEndpoint": "https://subgraph.satsuma-prod.com/superfluid/arbitrum-goerli/api"
+            "hostedEndpoint": "https://subgraph.satsuma-prod.com/c5br3jaVlJI6/superfluid/arbitrum-goerli/api"
         }
     },
     {
@@ -155,7 +155,7 @@
         "explorer": "https://gnosisscan.io",
         "subgraphV1": {
             "name": "protocol-v1-xdai",
-            "hostedEndpoint": "https://subgraph.satsuma-prod.com/superfluid/xdai/api"
+            "hostedEndpoint": "https://subgraph.satsuma-prod.com/c5br3jaVlJI6/superfluid/xdai/api"
         }
     },
     {
@@ -323,7 +323,7 @@
         "explorer": "https://etherscan.io",
         "subgraphV1": {
             "name": "protocol-v1-eth-mainnet",
-            "hostedEndpoint": "https://subgraph.satsuma-prod.com/superfluid/eth-mainnet/api"
+            "hostedEndpoint": "https://subgraph.satsuma-prod.com/c5br3jaVlJI6/superfluid/eth-mainnet/api"
         }
     }
 ]

--- a/networks.json
+++ b/networks.json
@@ -101,7 +101,7 @@
         "explorer": "https://goerli.arbiscan.io",
         "subgraphV1": {
             "name": "protocol-v1-arbitrum-goerli",
-            "hostedEndpoint": "https://subgraph.satsuma-prod.com/c5br3jaVlJI6/superfluid/arbitrum-goerli/api"
+            "hostedEndpoint": "https://api.thegraph.com/subgraphs/name/superfluid-finance/protocol-v1-arbitrum-goerli"
         }
     },
     {
@@ -155,7 +155,7 @@
         "explorer": "https://gnosisscan.io",
         "subgraphV1": {
             "name": "protocol-v1-xdai",
-            "hostedEndpoint": "https://subgraph.satsuma-prod.com/c5br3jaVlJI6/superfluid/xdai/api"
+            "hostedEndpoint": "https://api.thegraph.com/subgraphs/name/superfluid-finance/protocol-v1-xdai"
         }
     },
     {
@@ -323,7 +323,7 @@
         "explorer": "https://etherscan.io",
         "subgraphV1": {
             "name": "protocol-v1-eth-mainnet",
-            "hostedEndpoint": "https://subgraph.satsuma-prod.com/c5br3jaVlJI6/superfluid/eth-mainnet/api"
+            "hostedEndpoint": "https://api.thegraph.com/subgraphs/name/superfluid-finance/protocol-v1-eth-mainnet"
         }
     }
 ]


### PR DESCRIPTION
- Added query key into our endpoints (otherwise satsuma endpoints break from 31/12 onwards)
- Added a bash file and workflow check to ensure committed files are same as files built with `build.sh` using sha256sum of the files

Examples

Ignore the previous runs, was just wrestling with bash. 🥲 

Failed case (committed files not equal)
-  https://github.com/superfluid-finance/metadata/actions/runs/3740231001

Success case (commit the files for consistency)
- https://github.com/superfluid-finance/metadata/actions/runs/3740234438/jobs/6348367880