### PR TITLE
Satsuma Endpoints Added

### DIFF
--- a/README.md
+++ b/README.md
@@ -109,8 +109,7 @@ import("@superfluid-finance/metadata").then(module => sfMeta = module)
   explorer: 'https://optimistic.etherscan.io',
   subgraphV1: {
     name: 'protocol-v1-optimism-mainnet',
-    hostedEndpoint: 'https://api.thegraph.com/subgraphs/name/superfluid-finance/protocol-v1-optimism-mainnet',
-    satsumaEndpoint: null
+    hostedEndpoint: 'https://api.thegraph.com/subgraphs/name/superfluid-finance/protocol-v1-optimism-mainnet'
   }
 }
 ```

--- a/README.md
+++ b/README.md
@@ -109,7 +109,8 @@ import("@superfluid-finance/metadata").then(module => sfMeta = module)
   explorer: 'https://optimistic.etherscan.io',
   subgraphV1: {
     name: 'protocol-v1-optimism-mainnet',
-    hostedEndpoint: 'https://api.thegraph.com/subgraphs/name/superfluid-finance/protocol-v1-optimism-mainnet'
+    hostedEndpoint: 'https://api.thegraph.com/subgraphs/name/superfluid-finance/protocol-v1-optimism-mainnet',
+    satsumaEndpoint: null
   }
 }
 ```

--- a/main/networks/list.cjs
+++ b/main/networks/list.cjs
@@ -25,7 +25,8 @@ module.exports =
         "explorer": "https://goerli.etherscan.io",
         "subgraphV1": {
             "name": "protocol-v1-goerli",
-            "hostedEndpoint": "https://api.thegraph.com/subgraphs/name/superfluid-finance/protocol-v1-goerli"
+            "hostedEndpoint": "https://api.thegraph.com/subgraphs/name/superfluid-finance/protocol-v1-goerli",
+            "satsumaEndpoint": null
         },
         "publicRPCs": [
             "https://rpc.ankr.com/eth_goerli",
@@ -60,7 +61,8 @@ module.exports =
         "explorer": "https://mumbai.polygonscan.com",
         "subgraphV1": {
             "name": "protocol-v1-mumbai",
-            "hostedEndpoint": "https://api.thegraph.com/subgraphs/name/superfluid-finance/protocol-v1-mumbai"
+            "hostedEndpoint": "https://api.thegraph.com/subgraphs/name/superfluid-finance/protocol-v1-mumbai",
+            "satsumaEndpoint": null
         },
         "publicRPCs": [
             "https://rpc.ankr.com/polygon_mumbai",
@@ -91,7 +93,8 @@ module.exports =
         "explorer": "https://goerli-optimism.etherscan.io",
         "subgraphV1": {
             "name": "protocol-v1-optimism-goerli",
-            "hostedEndpoint": "https://api.thegraph.com/subgraphs/name/superfluid-finance/protocol-v1-optimism-goerli"
+            "hostedEndpoint": "https://api.thegraph.com/subgraphs/name/superfluid-finance/protocol-v1-optimism-goerli",
+            "satsumaEndpoint": null
         }
     },
     {
@@ -118,7 +121,8 @@ module.exports =
         "explorer": "https://goerli.arbiscan.io",
         "subgraphV1": {
             "name": "protocol-v1-arbitrum-goerli",
-            "hostedEndpoint": "https://api.thegraph.com/subgraphs/name/superfluid-finance/protocol-v1-arbitrum-goerli"
+            "hostedEndpoint": "https://api.thegraph.com/subgraphs/name/superfluid-finance/protocol-v1-arbitrum-goerli",
+            "satsumaEndpoint": null
         }
     },
     {
@@ -145,7 +149,8 @@ module.exports =
         "explorer": "https://testnet.snowtrace.io",
         "subgraphV1": {
             "name": "protocol-v1-avalanche-fuji",
-            "hostedEndpoint": "https://api.thegraph.com/subgraphs/name/superfluid-finance/protocol-v1-avalanche-fuji"
+            "hostedEndpoint": "https://api.thegraph.com/subgraphs/name/superfluid-finance/protocol-v1-avalanche-fuji",
+            "satsumaEndpoint": null
         }
     },
     {
@@ -179,7 +184,8 @@ module.exports =
         "explorer": "https://gnosisscan.io",
         "subgraphV1": {
             "name": "protocol-v1-xdai",
-            "hostedEndpoint": "https://api.thegraph.com/subgraphs/name/superfluid-finance/protocol-v1-xdai"
+            "hostedEndpoint": "https://api.thegraph.com/subgraphs/name/superfluid-finance/protocol-v1-xdai",
+            "satsumaEndpoint": "https://subgraph.satsuma-prod.com/c5br3jaVlJI6/superfluid/xdai/api"
         },
         "publicRPCs": [
             "https://rpc.gnosischain.com",
@@ -215,7 +221,8 @@ module.exports =
         "explorer": "https://polygonscan.com",
         "subgraphV1": {
             "name": "protocol-v1-matic",
-            "hostedEndpoint": "https://api.thegraph.com/subgraphs/name/superfluid-finance/protocol-v1-matic"
+            "hostedEndpoint": "https://api.thegraph.com/subgraphs/name/superfluid-finance/protocol-v1-matic",
+            "satsumaEndpoint": "https://subgraph.satsuma-prod.com/c5br3jaVlJI6/superfluid/matic/api"
         },
         "publicRPCs": [
             "https://polygon-rpc.com",
@@ -251,7 +258,8 @@ module.exports =
         "explorer": "https://optimistic.etherscan.io",
         "subgraphV1": {
             "name": "protocol-v1-optimism-mainnet",
-            "hostedEndpoint": "https://api.thegraph.com/subgraphs/name/superfluid-finance/protocol-v1-optimism-mainnet"
+            "hostedEndpoint": "https://api.thegraph.com/subgraphs/name/superfluid-finance/protocol-v1-optimism-mainnet",
+            "satsumaEndpoint": null
         },
         "publicRPCs": [
             "https://mainnet.optimism.io",
@@ -287,7 +295,8 @@ module.exports =
         "explorer": "https://arbiscan.io",
         "subgraphV1": {
             "name": "protocol-v1-arbitrum-one",
-            "hostedEndpoint": "https://api.thegraph.com/subgraphs/name/superfluid-finance/protocol-v1-arbitrum-one"
+            "hostedEndpoint": "https://api.thegraph.com/subgraphs/name/superfluid-finance/protocol-v1-arbitrum-one",
+            "satsumaEndpoint": null
         },
         "publicRPCs": [
             "https://arb1.arbitrum.io/rpc",
@@ -323,7 +332,8 @@ module.exports =
         "explorer": "https://snowtrace.io",
         "subgraphV1": {
             "name": "protocol-v1-avalanche-c",
-            "hostedEndpoint": "https://api.thegraph.com/subgraphs/name/superfluid-finance/protocol-v1-avalanche-c"
+            "hostedEndpoint": "https://api.thegraph.com/subgraphs/name/superfluid-finance/protocol-v1-avalanche-c",
+            "satsumaEndpoint": null
         },
         "publicRPCs": [
             "https://api.avax.network/ext/bc/C/rpc",
@@ -359,7 +369,8 @@ module.exports =
         "explorer": "https://bscscan.com",
         "subgraphV1": {
             "name": "protocol-v1-bsc-mainnet",
-            "hostedEndpoint": "https://api.thegraph.com/subgraphs/name/superfluid-finance/protocol-v1-bsc-mainnet"
+            "hostedEndpoint": "https://api.thegraph.com/subgraphs/name/superfluid-finance/protocol-v1-bsc-mainnet",
+            "satsumaEndpoint": null
         },
         "publicRPCs": [
             "https://bscrpc.com",
@@ -395,7 +406,8 @@ module.exports =
         "explorer": "https://etherscan.io",
         "subgraphV1": {
             "name": "protocol-v1-eth-mainnet",
-            "hostedEndpoint": "https://api.thegraph.com/subgraphs/name/superfluid-finance/protocol-v1-eth-mainnet"
+            "hostedEndpoint": "https://api.thegraph.com/subgraphs/name/superfluid-finance/protocol-v1-eth-mainnet",
+            "satsumaEndpoint": "https://subgraph.satsuma-prod.com/c5br3jaVlJI6/superfluid/eth-mainnet/api"
         },
         "publicRPCs": [
             "https://cloudflare-eth.com",
@@ -429,7 +441,8 @@ module.exports =
         "explorer": "https://celoscan.io",
         "subgraphV1": {
             "name": "protocol-v1-celo-mainnet",
-            "hostedEndpoint": "https://api.thegraph.com/subgraphs/name/superfluid-finance/protocol-v1-celo-mainnet"
+            "hostedEndpoint": "https://api.thegraph.com/subgraphs/name/superfluid-finance/protocol-v1-celo-mainnet",
+            "satsumaEndpoint": null
         },
         "publicRPCs": [
             "https://forno.celo.org",

--- a/main/networks/list.cjs
+++ b/main/networks/list.cjs
@@ -26,7 +26,6 @@ module.exports =
         "subgraphV1": {
             "name": "protocol-v1-goerli",
             "hostedEndpoint": "https://api.thegraph.com/subgraphs/name/superfluid-finance/protocol-v1-goerli",
-            "satsumaEndpoint": null
         },
         "publicRPCs": [
             "https://rpc.ankr.com/eth_goerli",
@@ -62,7 +61,6 @@ module.exports =
         "subgraphV1": {
             "name": "protocol-v1-mumbai",
             "hostedEndpoint": "https://api.thegraph.com/subgraphs/name/superfluid-finance/protocol-v1-mumbai",
-            "satsumaEndpoint": null
         },
         "publicRPCs": [
             "https://rpc.ankr.com/polygon_mumbai",
@@ -94,7 +92,6 @@ module.exports =
         "subgraphV1": {
             "name": "protocol-v1-optimism-goerli",
             "hostedEndpoint": "https://api.thegraph.com/subgraphs/name/superfluid-finance/protocol-v1-optimism-goerli",
-            "satsumaEndpoint": null
         }
     },
     {
@@ -122,7 +119,6 @@ module.exports =
         "subgraphV1": {
             "name": "protocol-v1-arbitrum-goerli",
             "hostedEndpoint": "https://api.thegraph.com/subgraphs/name/superfluid-finance/protocol-v1-arbitrum-goerli",
-            "satsumaEndpoint": null
         }
     },
     {
@@ -150,7 +146,6 @@ module.exports =
         "subgraphV1": {
             "name": "protocol-v1-avalanche-fuji",
             "hostedEndpoint": "https://api.thegraph.com/subgraphs/name/superfluid-finance/protocol-v1-avalanche-fuji",
-            "satsumaEndpoint": null
         }
     },
     {
@@ -259,7 +254,6 @@ module.exports =
         "subgraphV1": {
             "name": "protocol-v1-optimism-mainnet",
             "hostedEndpoint": "https://api.thegraph.com/subgraphs/name/superfluid-finance/protocol-v1-optimism-mainnet",
-            "satsumaEndpoint": null
         },
         "publicRPCs": [
             "https://mainnet.optimism.io",
@@ -296,7 +290,6 @@ module.exports =
         "subgraphV1": {
             "name": "protocol-v1-arbitrum-one",
             "hostedEndpoint": "https://api.thegraph.com/subgraphs/name/superfluid-finance/protocol-v1-arbitrum-one",
-            "satsumaEndpoint": null
         },
         "publicRPCs": [
             "https://arb1.arbitrum.io/rpc",
@@ -333,7 +326,6 @@ module.exports =
         "subgraphV1": {
             "name": "protocol-v1-avalanche-c",
             "hostedEndpoint": "https://api.thegraph.com/subgraphs/name/superfluid-finance/protocol-v1-avalanche-c",
-            "satsumaEndpoint": null
         },
         "publicRPCs": [
             "https://api.avax.network/ext/bc/C/rpc",
@@ -370,7 +362,6 @@ module.exports =
         "subgraphV1": {
             "name": "protocol-v1-bsc-mainnet",
             "hostedEndpoint": "https://api.thegraph.com/subgraphs/name/superfluid-finance/protocol-v1-bsc-mainnet",
-            "satsumaEndpoint": null
         },
         "publicRPCs": [
             "https://bscrpc.com",
@@ -442,7 +433,6 @@ module.exports =
         "subgraphV1": {
             "name": "protocol-v1-celo-mainnet",
             "hostedEndpoint": "https://api.thegraph.com/subgraphs/name/superfluid-finance/protocol-v1-celo-mainnet",
-            "satsumaEndpoint": null
         },
         "publicRPCs": [
             "https://forno.celo.org",

--- a/module/networks/list.d.ts
+++ b/module/networks/list.d.ts
@@ -12,6 +12,7 @@ interface ContractAddresses {
 interface SubgraphData {
     readonly name: string;
     readonly hostedEndpoint: string;
+    readonly satsumaEndpoint: string | null;
 }
 export interface NetworkMetaData {
     readonly name: string;

--- a/module/networks/list.js
+++ b/module/networks/list.js
@@ -26,7 +26,6 @@ export default
         "subgraphV1": {
             "name": "protocol-v1-goerli",
             "hostedEndpoint": "https://api.thegraph.com/subgraphs/name/superfluid-finance/protocol-v1-goerli",
-            "satsumaEndpoint": null
         },
         "publicRPCs": [
             "https://rpc.ankr.com/eth_goerli",
@@ -62,7 +61,6 @@ export default
         "subgraphV1": {
             "name": "protocol-v1-mumbai",
             "hostedEndpoint": "https://api.thegraph.com/subgraphs/name/superfluid-finance/protocol-v1-mumbai",
-            "satsumaEndpoint": null
         },
         "publicRPCs": [
             "https://rpc.ankr.com/polygon_mumbai",
@@ -94,7 +92,6 @@ export default
         "subgraphV1": {
             "name": "protocol-v1-optimism-goerli",
             "hostedEndpoint": "https://api.thegraph.com/subgraphs/name/superfluid-finance/protocol-v1-optimism-goerli",
-            "satsumaEndpoint": null
         }
     },
     {
@@ -122,7 +119,6 @@ export default
         "subgraphV1": {
             "name": "protocol-v1-arbitrum-goerli",
             "hostedEndpoint": "https://api.thegraph.com/subgraphs/name/superfluid-finance/protocol-v1-arbitrum-goerli",
-            "satsumaEndpoint": null
         }
     },
     {
@@ -150,7 +146,6 @@ export default
         "subgraphV1": {
             "name": "protocol-v1-avalanche-fuji",
             "hostedEndpoint": "https://api.thegraph.com/subgraphs/name/superfluid-finance/protocol-v1-avalanche-fuji",
-            "satsumaEndpoint": null
         }
     },
     {
@@ -259,7 +254,6 @@ export default
         "subgraphV1": {
             "name": "protocol-v1-optimism-mainnet",
             "hostedEndpoint": "https://api.thegraph.com/subgraphs/name/superfluid-finance/protocol-v1-optimism-mainnet",
-            "satsumaEndpoint": null
         },
         "publicRPCs": [
             "https://mainnet.optimism.io",
@@ -296,7 +290,6 @@ export default
         "subgraphV1": {
             "name": "protocol-v1-arbitrum-one",
             "hostedEndpoint": "https://api.thegraph.com/subgraphs/name/superfluid-finance/protocol-v1-arbitrum-one",
-            "satsumaEndpoint": null
         },
         "publicRPCs": [
             "https://arb1.arbitrum.io/rpc",
@@ -333,7 +326,6 @@ export default
         "subgraphV1": {
             "name": "protocol-v1-avalanche-c",
             "hostedEndpoint": "https://api.thegraph.com/subgraphs/name/superfluid-finance/protocol-v1-avalanche-c",
-            "satsumaEndpoint": null
         },
         "publicRPCs": [
             "https://api.avax.network/ext/bc/C/rpc",
@@ -370,7 +362,6 @@ export default
         "subgraphV1": {
             "name": "protocol-v1-bsc-mainnet",
             "hostedEndpoint": "https://api.thegraph.com/subgraphs/name/superfluid-finance/protocol-v1-bsc-mainnet",
-            "satsumaEndpoint": null
         },
         "publicRPCs": [
             "https://bscrpc.com",
@@ -442,7 +433,6 @@ export default
         "subgraphV1": {
             "name": "protocol-v1-celo-mainnet",
             "hostedEndpoint": "https://api.thegraph.com/subgraphs/name/superfluid-finance/protocol-v1-celo-mainnet",
-            "satsumaEndpoint": null
         },
         "publicRPCs": [
             "https://forno.celo.org",

--- a/module/networks/list.js
+++ b/module/networks/list.js
@@ -25,7 +25,8 @@ export default
         "explorer": "https://goerli.etherscan.io",
         "subgraphV1": {
             "name": "protocol-v1-goerli",
-            "hostedEndpoint": "https://api.thegraph.com/subgraphs/name/superfluid-finance/protocol-v1-goerli"
+            "hostedEndpoint": "https://api.thegraph.com/subgraphs/name/superfluid-finance/protocol-v1-goerli",
+            "satsumaEndpoint": null
         },
         "publicRPCs": [
             "https://rpc.ankr.com/eth_goerli",
@@ -60,7 +61,8 @@ export default
         "explorer": "https://mumbai.polygonscan.com",
         "subgraphV1": {
             "name": "protocol-v1-mumbai",
-            "hostedEndpoint": "https://api.thegraph.com/subgraphs/name/superfluid-finance/protocol-v1-mumbai"
+            "hostedEndpoint": "https://api.thegraph.com/subgraphs/name/superfluid-finance/protocol-v1-mumbai",
+            "satsumaEndpoint": null
         },
         "publicRPCs": [
             "https://rpc.ankr.com/polygon_mumbai",
@@ -91,7 +93,8 @@ export default
         "explorer": "https://goerli-optimism.etherscan.io",
         "subgraphV1": {
             "name": "protocol-v1-optimism-goerli",
-            "hostedEndpoint": "https://api.thegraph.com/subgraphs/name/superfluid-finance/protocol-v1-optimism-goerli"
+            "hostedEndpoint": "https://api.thegraph.com/subgraphs/name/superfluid-finance/protocol-v1-optimism-goerli",
+            "satsumaEndpoint": null
         }
     },
     {
@@ -118,7 +121,8 @@ export default
         "explorer": "https://goerli.arbiscan.io",
         "subgraphV1": {
             "name": "protocol-v1-arbitrum-goerli",
-            "hostedEndpoint": "https://api.thegraph.com/subgraphs/name/superfluid-finance/protocol-v1-arbitrum-goerli"
+            "hostedEndpoint": "https://api.thegraph.com/subgraphs/name/superfluid-finance/protocol-v1-arbitrum-goerli",
+            "satsumaEndpoint": null
         }
     },
     {
@@ -145,7 +149,8 @@ export default
         "explorer": "https://testnet.snowtrace.io",
         "subgraphV1": {
             "name": "protocol-v1-avalanche-fuji",
-            "hostedEndpoint": "https://api.thegraph.com/subgraphs/name/superfluid-finance/protocol-v1-avalanche-fuji"
+            "hostedEndpoint": "https://api.thegraph.com/subgraphs/name/superfluid-finance/protocol-v1-avalanche-fuji",
+            "satsumaEndpoint": null
         }
     },
     {
@@ -179,7 +184,8 @@ export default
         "explorer": "https://gnosisscan.io",
         "subgraphV1": {
             "name": "protocol-v1-xdai",
-            "hostedEndpoint": "https://api.thegraph.com/subgraphs/name/superfluid-finance/protocol-v1-xdai"
+            "hostedEndpoint": "https://api.thegraph.com/subgraphs/name/superfluid-finance/protocol-v1-xdai",
+            "satsumaEndpoint": "https://subgraph.satsuma-prod.com/c5br3jaVlJI6/superfluid/xdai/api"
         },
         "publicRPCs": [
             "https://rpc.gnosischain.com",
@@ -215,7 +221,8 @@ export default
         "explorer": "https://polygonscan.com",
         "subgraphV1": {
             "name": "protocol-v1-matic",
-            "hostedEndpoint": "https://api.thegraph.com/subgraphs/name/superfluid-finance/protocol-v1-matic"
+            "hostedEndpoint": "https://api.thegraph.com/subgraphs/name/superfluid-finance/protocol-v1-matic",
+            "satsumaEndpoint": "https://subgraph.satsuma-prod.com/c5br3jaVlJI6/superfluid/matic/api"
         },
         "publicRPCs": [
             "https://polygon-rpc.com",
@@ -251,7 +258,8 @@ export default
         "explorer": "https://optimistic.etherscan.io",
         "subgraphV1": {
             "name": "protocol-v1-optimism-mainnet",
-            "hostedEndpoint": "https://api.thegraph.com/subgraphs/name/superfluid-finance/protocol-v1-optimism-mainnet"
+            "hostedEndpoint": "https://api.thegraph.com/subgraphs/name/superfluid-finance/protocol-v1-optimism-mainnet",
+            "satsumaEndpoint": null
         },
         "publicRPCs": [
             "https://mainnet.optimism.io",
@@ -287,7 +295,8 @@ export default
         "explorer": "https://arbiscan.io",
         "subgraphV1": {
             "name": "protocol-v1-arbitrum-one",
-            "hostedEndpoint": "https://api.thegraph.com/subgraphs/name/superfluid-finance/protocol-v1-arbitrum-one"
+            "hostedEndpoint": "https://api.thegraph.com/subgraphs/name/superfluid-finance/protocol-v1-arbitrum-one",
+            "satsumaEndpoint": null
         },
         "publicRPCs": [
             "https://arb1.arbitrum.io/rpc",
@@ -323,7 +332,8 @@ export default
         "explorer": "https://snowtrace.io",
         "subgraphV1": {
             "name": "protocol-v1-avalanche-c",
-            "hostedEndpoint": "https://api.thegraph.com/subgraphs/name/superfluid-finance/protocol-v1-avalanche-c"
+            "hostedEndpoint": "https://api.thegraph.com/subgraphs/name/superfluid-finance/protocol-v1-avalanche-c",
+            "satsumaEndpoint": null
         },
         "publicRPCs": [
             "https://api.avax.network/ext/bc/C/rpc",
@@ -359,7 +369,8 @@ export default
         "explorer": "https://bscscan.com",
         "subgraphV1": {
             "name": "protocol-v1-bsc-mainnet",
-            "hostedEndpoint": "https://api.thegraph.com/subgraphs/name/superfluid-finance/protocol-v1-bsc-mainnet"
+            "hostedEndpoint": "https://api.thegraph.com/subgraphs/name/superfluid-finance/protocol-v1-bsc-mainnet",
+            "satsumaEndpoint": null
         },
         "publicRPCs": [
             "https://bscrpc.com",
@@ -395,7 +406,8 @@ export default
         "explorer": "https://etherscan.io",
         "subgraphV1": {
             "name": "protocol-v1-eth-mainnet",
-            "hostedEndpoint": "https://api.thegraph.com/subgraphs/name/superfluid-finance/protocol-v1-eth-mainnet"
+            "hostedEndpoint": "https://api.thegraph.com/subgraphs/name/superfluid-finance/protocol-v1-eth-mainnet",
+            "satsumaEndpoint": "https://subgraph.satsuma-prod.com/c5br3jaVlJI6/superfluid/eth-mainnet/api"
         },
         "publicRPCs": [
             "https://cloudflare-eth.com",
@@ -429,7 +441,8 @@ export default
         "explorer": "https://celoscan.io",
         "subgraphV1": {
             "name": "protocol-v1-celo-mainnet",
-            "hostedEndpoint": "https://api.thegraph.com/subgraphs/name/superfluid-finance/protocol-v1-celo-mainnet"
+            "hostedEndpoint": "https://api.thegraph.com/subgraphs/name/superfluid-finance/protocol-v1-celo-mainnet",
+            "satsumaEndpoint": null
         },
         "publicRPCs": [
             "https://forno.celo.org",

--- a/networks.json
+++ b/networks.json
@@ -24,7 +24,8 @@
         "explorer": "https://goerli.etherscan.io",
         "subgraphV1": {
             "name": "protocol-v1-goerli",
-            "hostedEndpoint": "https://api.thegraph.com/subgraphs/name/superfluid-finance/protocol-v1-goerli"
+            "hostedEndpoint": "https://api.thegraph.com/subgraphs/name/superfluid-finance/protocol-v1-goerli",
+            "satsumaEndpoint": null
         },
         "publicRPCs": [
             "https://rpc.ankr.com/eth_goerli",
@@ -59,7 +60,8 @@
         "explorer": "https://mumbai.polygonscan.com",
         "subgraphV1": {
             "name": "protocol-v1-mumbai",
-            "hostedEndpoint": "https://api.thegraph.com/subgraphs/name/superfluid-finance/protocol-v1-mumbai"
+            "hostedEndpoint": "https://api.thegraph.com/subgraphs/name/superfluid-finance/protocol-v1-mumbai",
+            "satsumaEndpoint": null
         },
         "publicRPCs": [
             "https://rpc.ankr.com/polygon_mumbai",
@@ -90,7 +92,8 @@
         "explorer": "https://goerli-optimism.etherscan.io",
         "subgraphV1": {
             "name": "protocol-v1-optimism-goerli",
-            "hostedEndpoint": "https://api.thegraph.com/subgraphs/name/superfluid-finance/protocol-v1-optimism-goerli"
+            "hostedEndpoint": "https://api.thegraph.com/subgraphs/name/superfluid-finance/protocol-v1-optimism-goerli",
+            "satsumaEndpoint": null
         }
     },
     {
@@ -117,7 +120,8 @@
         "explorer": "https://goerli.arbiscan.io",
         "subgraphV1": {
             "name": "protocol-v1-arbitrum-goerli",
-            "hostedEndpoint": "https://api.thegraph.com/subgraphs/name/superfluid-finance/protocol-v1-arbitrum-goerli"
+            "hostedEndpoint": "https://api.thegraph.com/subgraphs/name/superfluid-finance/protocol-v1-arbitrum-goerli",
+            "satsumaEndpoint": null
         }
     },
     {
@@ -144,7 +148,8 @@
         "explorer": "https://testnet.snowtrace.io",
         "subgraphV1": {
             "name": "protocol-v1-avalanche-fuji",
-            "hostedEndpoint": "https://api.thegraph.com/subgraphs/name/superfluid-finance/protocol-v1-avalanche-fuji"
+            "hostedEndpoint": "https://api.thegraph.com/subgraphs/name/superfluid-finance/protocol-v1-avalanche-fuji",
+            "satsumaEndpoint": null
         }
     },
     {
@@ -178,7 +183,8 @@
         "explorer": "https://gnosisscan.io",
         "subgraphV1": {
             "name": "protocol-v1-xdai",
-            "hostedEndpoint": "https://api.thegraph.com/subgraphs/name/superfluid-finance/protocol-v1-xdai"
+            "hostedEndpoint": "https://api.thegraph.com/subgraphs/name/superfluid-finance/protocol-v1-xdai",
+            "satsumaEndpoint": "https://subgraph.satsuma-prod.com/c5br3jaVlJI6/superfluid/xdai/api"
         },
         "publicRPCs": [
             "https://rpc.gnosischain.com",
@@ -214,7 +220,8 @@
         "explorer": "https://polygonscan.com",
         "subgraphV1": {
             "name": "protocol-v1-matic",
-            "hostedEndpoint": "https://api.thegraph.com/subgraphs/name/superfluid-finance/protocol-v1-matic"
+            "hostedEndpoint": "https://api.thegraph.com/subgraphs/name/superfluid-finance/protocol-v1-matic",
+            "satsumaEndpoint": "https://subgraph.satsuma-prod.com/c5br3jaVlJI6/superfluid/matic/api"
         },
         "publicRPCs": [
             "https://polygon-rpc.com",
@@ -250,7 +257,8 @@
         "explorer": "https://optimistic.etherscan.io",
         "subgraphV1": {
             "name": "protocol-v1-optimism-mainnet",
-            "hostedEndpoint": "https://api.thegraph.com/subgraphs/name/superfluid-finance/protocol-v1-optimism-mainnet"
+            "hostedEndpoint": "https://api.thegraph.com/subgraphs/name/superfluid-finance/protocol-v1-optimism-mainnet",
+            "satsumaEndpoint": null
         },
         "publicRPCs": [
             "https://mainnet.optimism.io",
@@ -286,7 +294,8 @@
         "explorer": "https://arbiscan.io",
         "subgraphV1": {
             "name": "protocol-v1-arbitrum-one",
-            "hostedEndpoint": "https://api.thegraph.com/subgraphs/name/superfluid-finance/protocol-v1-arbitrum-one"
+            "hostedEndpoint": "https://api.thegraph.com/subgraphs/name/superfluid-finance/protocol-v1-arbitrum-one",
+            "satsumaEndpoint": null
         },
         "publicRPCs": [
             "https://arb1.arbitrum.io/rpc",
@@ -322,7 +331,8 @@
         "explorer": "https://snowtrace.io",
         "subgraphV1": {
             "name": "protocol-v1-avalanche-c",
-            "hostedEndpoint": "https://api.thegraph.com/subgraphs/name/superfluid-finance/protocol-v1-avalanche-c"
+            "hostedEndpoint": "https://api.thegraph.com/subgraphs/name/superfluid-finance/protocol-v1-avalanche-c",
+            "satsumaEndpoint": null
         },
         "publicRPCs": [
             "https://api.avax.network/ext/bc/C/rpc",
@@ -358,7 +368,8 @@
         "explorer": "https://bscscan.com",
         "subgraphV1": {
             "name": "protocol-v1-bsc-mainnet",
-            "hostedEndpoint": "https://api.thegraph.com/subgraphs/name/superfluid-finance/protocol-v1-bsc-mainnet"
+            "hostedEndpoint": "https://api.thegraph.com/subgraphs/name/superfluid-finance/protocol-v1-bsc-mainnet",
+            "satsumaEndpoint": null
         },
         "publicRPCs": [
             "https://bscrpc.com",
@@ -394,7 +405,8 @@
         "explorer": "https://etherscan.io",
         "subgraphV1": {
             "name": "protocol-v1-eth-mainnet",
-            "hostedEndpoint": "https://api.thegraph.com/subgraphs/name/superfluid-finance/protocol-v1-eth-mainnet"
+            "hostedEndpoint": "https://api.thegraph.com/subgraphs/name/superfluid-finance/protocol-v1-eth-mainnet",
+            "satsumaEndpoint": "https://subgraph.satsuma-prod.com/c5br3jaVlJI6/superfluid/eth-mainnet/api"
         },
         "publicRPCs": [
             "https://cloudflare-eth.com",
@@ -428,7 +440,8 @@
         "explorer": "https://celoscan.io",
         "subgraphV1": {
             "name": "protocol-v1-celo-mainnet",
-            "hostedEndpoint": "https://api.thegraph.com/subgraphs/name/superfluid-finance/protocol-v1-celo-mainnet"
+            "hostedEndpoint": "https://api.thegraph.com/subgraphs/name/superfluid-finance/protocol-v1-celo-mainnet",
+            "satsumaEndpoint": null
         },
         "publicRPCs": [
             "https://forno.celo.org",

--- a/networks.json
+++ b/networks.json
@@ -25,7 +25,6 @@
         "subgraphV1": {
             "name": "protocol-v1-goerli",
             "hostedEndpoint": "https://api.thegraph.com/subgraphs/name/superfluid-finance/protocol-v1-goerli",
-            "satsumaEndpoint": null
         },
         "publicRPCs": [
             "https://rpc.ankr.com/eth_goerli",
@@ -61,7 +60,6 @@
         "subgraphV1": {
             "name": "protocol-v1-mumbai",
             "hostedEndpoint": "https://api.thegraph.com/subgraphs/name/superfluid-finance/protocol-v1-mumbai",
-            "satsumaEndpoint": null
         },
         "publicRPCs": [
             "https://rpc.ankr.com/polygon_mumbai",
@@ -93,7 +91,6 @@
         "subgraphV1": {
             "name": "protocol-v1-optimism-goerli",
             "hostedEndpoint": "https://api.thegraph.com/subgraphs/name/superfluid-finance/protocol-v1-optimism-goerli",
-            "satsumaEndpoint": null
         }
     },
     {
@@ -121,7 +118,6 @@
         "subgraphV1": {
             "name": "protocol-v1-arbitrum-goerli",
             "hostedEndpoint": "https://api.thegraph.com/subgraphs/name/superfluid-finance/protocol-v1-arbitrum-goerli",
-            "satsumaEndpoint": null
         }
     },
     {
@@ -149,7 +145,6 @@
         "subgraphV1": {
             "name": "protocol-v1-avalanche-fuji",
             "hostedEndpoint": "https://api.thegraph.com/subgraphs/name/superfluid-finance/protocol-v1-avalanche-fuji",
-            "satsumaEndpoint": null
         }
     },
     {
@@ -258,7 +253,6 @@
         "subgraphV1": {
             "name": "protocol-v1-optimism-mainnet",
             "hostedEndpoint": "https://api.thegraph.com/subgraphs/name/superfluid-finance/protocol-v1-optimism-mainnet",
-            "satsumaEndpoint": null
         },
         "publicRPCs": [
             "https://mainnet.optimism.io",
@@ -295,7 +289,6 @@
         "subgraphV1": {
             "name": "protocol-v1-arbitrum-one",
             "hostedEndpoint": "https://api.thegraph.com/subgraphs/name/superfluid-finance/protocol-v1-arbitrum-one",
-            "satsumaEndpoint": null
         },
         "publicRPCs": [
             "https://arb1.arbitrum.io/rpc",
@@ -332,7 +325,6 @@
         "subgraphV1": {
             "name": "protocol-v1-avalanche-c",
             "hostedEndpoint": "https://api.thegraph.com/subgraphs/name/superfluid-finance/protocol-v1-avalanche-c",
-            "satsumaEndpoint": null
         },
         "publicRPCs": [
             "https://api.avax.network/ext/bc/C/rpc",
@@ -369,7 +361,6 @@
         "subgraphV1": {
             "name": "protocol-v1-bsc-mainnet",
             "hostedEndpoint": "https://api.thegraph.com/subgraphs/name/superfluid-finance/protocol-v1-bsc-mainnet",
-            "satsumaEndpoint": null
         },
         "publicRPCs": [
             "https://bscrpc.com",
@@ -441,7 +432,6 @@
         "subgraphV1": {
             "name": "protocol-v1-celo-mainnet",
             "hostedEndpoint": "https://api.thegraph.com/subgraphs/name/superfluid-finance/protocol-v1-celo-mainnet",
-            "satsumaEndpoint": null
         },
         "publicRPCs": [
             "https://forno.celo.org",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@superfluid-finance/metadata",
-  "version": "1.1.2",
+  "version": "1.1.3",
   "description": "Superfluid Metadata",
   "main": "main/index.cjs",
   "module": "module/index.js",


### PR DESCRIPTION
## Context
We are currently paying for the satsuma endpoints, but not utilizing them anywhere.
It is important that our most utilized networks have high availability and are performant, the free hosted service provided by the Graph does not guarantee this, but Satsuma does as we are paying customers.

## Solution
Add the Satsuma endpoints into the `networks.json` file.
This also provides an implicit documentation of which endpoints we have on Satsuma.